### PR TITLE
Adding malloc.h to non-Windows platforms

### DIFF
--- a/SSE2NEONBinding.cpp
+++ b/SSE2NEONBinding.cpp
@@ -12,6 +12,7 @@
 
 #else
 
+#include <malloc.h>
 #include <stdlib.h>
 
 #endif


### PR DESCRIPTION
Otherwise, ::memalign doesn't get declared correctly.