### PR TITLE
Remove CFLAG neon from aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,12 @@
 #The C compiler to use 
 CC = g++
 #C flags
+uname_p := $(shell uname -p)
+ifeq ($(uname_p),aarch64)
+CFLAGS = -Wall
+else
 CFLAGS = -Wall -mfpu=neon
+endif
 #Preprocessor flags like include paths
 CPPFLAGS+=	-I. 
 #Add libraries to this, e.g. -lm for the math library
@@ -25,4 +30,4 @@ $(BINARY) : $(SRCS) $(DEPS)
 
 .PHONY: clean    
 clean :
-	-rm $(BINARY) *.o  *.out 2> /dev/null
+	-rm -f $(BINARY) *.o  *.out 2> /dev/null

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Rewriting code written for SSE to work on Neon is very time consuming.  This is 
 #include "SSE2NEON.h"
 ```
 
-- On Linux compile your code with the following gcc/g++ flag:   
+- On Linux ARM platform (exclude AArch64) compile your code with the following gcc/g++ flag:   
  ```
  -mfpu=neon 
  ```


### PR DESCRIPTION
-mfpu is not a valid option on aarch64 (arm64), so remove this flag if aarch64 detected

Ref:
https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html
https://lists.linaro.org/pipermail/linaro-toolchain/2016-July/005815.html
https://stackoverflow.com/a/29891469/2882845